### PR TITLE
Bump sharp version for Node 4.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/naturalatlas/tilestrata-sharp",
   "dependencies": {
-    "sharp": "^0.9.3"
+    "sharp": "^0.11.3"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe('Tranform Implementation "sharp"', function() {
 
 			transform.transform(server, req, inputBuffer, inputHeaders, function(err, buffer, headers) {
 				assert.instanceOf(err, Error);
-				assert.match(err.message, /Buffer contains an unsupported image format/);
+				assert.match(err.message, /Input buffer contains unsupported image format/);
 				done();
 			});
 		});


### PR DESCRIPTION
As is, tilestrata-sharp does not install with Node 4.x. This pull request bumps the version of sharp to add support for Node 4.x.
